### PR TITLE
Change instructions submit quiz for code cell

### DIFF
--- a/notebooks/python_sql_pandas.ipynb
+++ b/notebooks/python_sql_pandas.ipynb
@@ -524,12 +524,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NbConvertApp] Converting notebook python_sql_pandas.ipynb to html\n",
+      "[NbConvertApp] Writing 601720 bytes to python_sql_pandas.html\n"
+     ]
+    }
+   ],
    "source": [
     "%%bash\n",
-    "jupyter nbconvert datatoolkit_quiz.ipynb --to html"
+    "jupyter nbconvert --to html datatoolkit_quiz.ipynb"
    ]
   },
   {

--- a/notebooks/python_sql_pandas.ipynb
+++ b/notebooks/python_sql_pandas.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,21 +192,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'positive_sum' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-6-9b94f724e635>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# the cell should output True\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mpositive_sum\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m7\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'positive_sum' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# the cell should output True\n",
     "positive_sum == 7"
@@ -536,18 +524,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[NbConvertApp] Converting notebook python_sql_pandas.ipynb to html\n",
-      "[NbConvertApp] Writing 617452 bytes to python_sql_pandas.html\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "jupyter nbconvert datatoolkit_quiz.ipynb --to html"
@@ -557,7 +536,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  ☁️Almost done! Last step is to go back to Kitt and run the last command to be ."
+    "###  ☁️Almost done! Last step is to go back to Kitt and follow the last instructions to upload it on Kitt."
    ]
   }
  ],

--- a/notebooks/python_sql_pandas.ipynb
+++ b/notebooks/python_sql_pandas.ipynb
@@ -524,18 +524,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[NbConvertApp] Converting notebook python_sql_pandas.ipynb to html\n",
-      "[NbConvertApp] Writing 601720 bytes to python_sql_pandas.html\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "jupyter nbconvert --to html datatoolkit_quiz.ipynb"
@@ -545,7 +536,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  ☁️Almost done! Last step is to go back to Kitt and follow the last instructions to upload it on Kitt."
+    "###  ☁️Almost done! Last step is to go back to Kitt and follow the last instructions to submit your quiz."
    ]
   }
  ],

--- a/notebooks/python_sql_pandas.ipynb
+++ b/notebooks/python_sql_pandas.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,9 +192,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'positive_sum' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-6-9b94f724e635>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# the cell should output True\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mpositive_sum\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m7\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'positive_sum' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# the cell should output True\n",
     "positive_sum == 7"
@@ -488,7 +500,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# your code here\n"
+    "# your code here\n",
+    "hello"
    ]
   },
   {
@@ -511,31 +524,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Submit your quiz"
+    "## Submit your quiz in 2 steps:"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Convert your notebook as a PDF file with `nbconvert` from your terminal:\n",
-    "\n",
-    "```bash\n",
-    "\n",
-    "jupyter nbconvert --to html --allow-chromium-download datatoolkit_quiz.ipynb\n",
-    "```\n",
-    "\n",
-    "It generates a HTML version of your quiz.\n",
-    "\n",
-    "☁️ Next Step: Upload your quiz on Kitt.\n"
+    "### Convert your notebook as a HTML file with `nbconvert` by running the cell below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NbConvertApp] Converting notebook python_sql_pandas.ipynb to html\n",
+      "[NbConvertApp] Writing 617452 bytes to python_sql_pandas.html\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%bash\n",
+    "jupyter nbconvert datatoolkit_quiz.ipynb --to html"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  ☁️Almost done! Last step is to go back to Kitt and run the last command to be ."
+   ]
   }
  ],
  "metadata": {
@@ -543,6 +566,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
**Context:**

[PR Kitt-data-quizzes #4805](https://github.com/lewagon/kitt/pull/4805/checks?check_run_id=2325463569)

<img width="1106" alt="Screen Shot 2021-04-12 at 19 18 58" src="https://user-images.githubusercontent.com/25570813/114435143-20231f00-9bc4-11eb-9073-d7add5ea7938.png">

@krokrob, as agreed with @Eschults, the conversion will be an executable code cell.


I changed the wording, so it's a bit more clear for students what last steps they have to do to submit their quiz.